### PR TITLE
Fix a bug to create candidates

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,20 @@
 
 const { execSync } = require('child_process');
 
+let _revParseCache = { };
+function revParse(name) {
+  if (!_revParseCache[name]) {
+    _revParseCache[name] = execSync(`git rev-parse ${name}`, { encoding: 'utf8' }).replace('\n', '');
+  }
+  return _revParseCache[name];
+}
+
 const currentName = execSync('git branch | grep \"^\\*\" | cut -b 3-', { encoding: 'utf8' });
 const shownBranches = execSync('git show-branch -a --sha1-name', { encoding: 'utf8' }).split(/\n/);
 const separatorIndex = shownBranches.findIndex((b) => /^--/.test(b));
 const branches = [];
-const currentHash = execSync(`git rev-parse ${currentName}`, { encoding: 'utf8' }).replace('\n', '');
-const firstParentHashes = execSync('git log -n 1000 --oneline --first-parent', { encoding: 'utf8' }).split('\n').map(log => log.split(' ')[0]);
+const currentHash = revParse(currentName);
+const firstParentHashes = execSync('git log -n 1000 --oneline', { encoding: 'utf8' }).split('\n').map(log => log.split(' ')[0]);
 
 let currentIndex;
 let baseHash = '';
@@ -32,7 +40,7 @@ const candidateHashes = shownBranches
         if (i === currentIndex) return;
         if (s === ' ') return;
         const name = branches[i];
-        const hash = execSync(`git rev-parse ${name}`, { encoding: 'utf8' }).replace('\n', '');
+        const hash = revParse(name);
         if (hash === currentHash) return;
         return true;
       })


### PR DESCRIPTION
Fix the following error.

```txt
TypeError: Cannot read property 'Symbol(Symbol.iterator)' of undefined
    at traverseLog (/pipeline/source/node_modules/git-base-hash/index.js:64:37)
    at Array.find (native)
    at Object.<anonymous> (/pipeline/source/node_modules/git-base-hash/index.js:71:32)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:394:7)
```

This error occurs when `git show-branch -a --sha1-name` returns a result such as:

```sh
* [feature-x] Merge branch 'master' into feature-x
 ! [master] add d
--
-  [7f2a3a8] Merge branch 'master' into feature-x
*+ [a2af753] add d    <--- base hash we want to get
```

And `git log` shows the following 

```txt
7f2a3a8 Merge branch 'master' into feature-x
a2af753 add d           <--- base hash candidate
a192189 add x2
d3ea9e2 add x
:
```

You use `git log --first-parent` and it does not show logs of upstream branches(such as master), so in the above example, `--first-parent` hides the second line `a2af753 add d add d`, finally `candidateHashes` is missing this hash `a2af753`.

One more thing, `git rev-parse <name>` are called many times in `Array.map` loop. So I've applied fly-weight pattern reducing `execSync` calls ;)